### PR TITLE
Flounder changes

### DIFF
--- a/recipes-wam/chromium/chromium53.inc
+++ b/recipes-wam/chromium/chromium53.inc
@@ -7,7 +7,7 @@ DEPENDS_append = " af-main-native"
 # for bindings  af-binder is required.
 DEPENDS_append = " af-binder"
 
-SRC_URI = "git://github.com/webosose/${PN}.git;branch=@1.agl;protocol=https"
+SRC_URI = "git://github.com/Igalia/${PN}.git;branch=flounder;protocol=https"
 S = "${WORKDIR}/git"
 SRCREV = "${AUTOREV}"
 

--- a/recipes-wam/wam/files/0001-Remove-Restart-condition.patch
+++ b/recipes-wam/wam/files/0001-Remove-Restart-condition.patch
@@ -1,0 +1,26 @@
+From fbb3e17eb16d3beba52107c53529c321bd5b725d Mon Sep 17 00:00:00 2001
+From: Julie Jeongeun Kim <jkim@igalia.com>
+Date: Wed, 17 Oct 2018 14:04:02 +0900
+Subject: [PATCH] Remove Restart condition
+
+It causes continue restarting. Even if it's removed,
+it's launched without problem  whenever users select WebApp.
+---
+ files/launch/WebAppMgr.service | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/files/launch/WebAppMgr.service b/files/launch/WebAppMgr.service
+index 5a5fe0a..d4461d5 100644
+--- a/files/launch/WebAppMgr.service
++++ b/files/launch/WebAppMgr.service
+@@ -20,7 +20,6 @@ Type=simple
+ OOMScoreAdjust=-1000
+ EnvironmentFile=-/etc/default/WebAppMgr.env
+ ExecStart=/usr/bin/WebAppMgr --no-sandbox --remote-debugging-port=9998 --user-data-dir="/home/0/wamdata" --webos-wam
+-Restart=on-failure
+ 
+ [Install]
+ WantedBy=multi-user.target
+-- 
+2.14.1
+

--- a/recipes-wam/wam/files/0001-Update-user-directory.patch
+++ b/recipes-wam/wam/files/0001-Update-user-directory.patch
@@ -1,0 +1,41 @@
+From 86fb04aa58cd5355c63e8b962370446e9c34f04c Mon Sep 17 00:00:00 2001
+From: Julie Jeongeun Kim <jkim@igalia.com>
+Date: Tue, 16 Oct 2018 16:54:03 +0900
+Subject: [PATCH] Update user directory
+
+It updates user directory path for flounder from
+"/home/root/" to "/home/0/"
+---
+ files/launch/WebAppMgr.env     | 2 +-
+ files/launch/WebAppMgr.service | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/files/launch/WebAppMgr.env b/files/launch/WebAppMgr.env
+index 1c0bc13..8d1a28e 100644
+--- a/files/launch/WebAppMgr.env
++++ b/files/launch/WebAppMgr.env
+@@ -26,7 +26,7 @@ WAM_SUSPEND_DELAY_IN_MS=250
+ #fi
+ 
+ # Set user data directory for WebAppMgr
+-WAM_DATA_PATH="/home/root/wamdata"
++WAM_DATA_PATH="/home/0/wamdata"
+ 
+ # ensure that wam data directories exist
+ #mkdir -p ${WAM_DATA_PATH}
+diff --git a/files/launch/WebAppMgr.service b/files/launch/WebAppMgr.service
+index 42dcb3b..5a5fe0a 100644
+--- a/files/launch/WebAppMgr.service
++++ b/files/launch/WebAppMgr.service
+@@ -19,7 +19,7 @@ Wants=weston.service
+ Type=simple
+ OOMScoreAdjust=-1000
+ EnvironmentFile=-/etc/default/WebAppMgr.env
+-ExecStart=/usr/bin/WebAppMgr --no-sandbox --remote-debugging-port=9998 --user-data-dir="/home/root/wamdata" --webos-wam
++ExecStart=/usr/bin/WebAppMgr --no-sandbox --remote-debugging-port=9998 --user-data-dir="/home/0/wamdata" --webos-wam
+ Restart=on-failure
+ 
+ [Install]
+-- 
+2.14.1
+

--- a/recipes-wam/wam/wam.bb
+++ b/recipes-wam/wam/wam.bb
@@ -14,7 +14,10 @@ RPROVIDES_${PN} += "virtual/webruntime"
 
 SRC_URI = "git://github.com/Igalia/${PN}.git;branch=flounder;protocol=https"
 
-SRC_URI += "file://0001-Used-new-WindowManager-APIs.patch"
+SRC_URI += "\
+    file://0001-Used-new-WindowManager-APIs.patch \
+    file://0001-Update-user-directory.patch \
+"
 
 S = "${WORKDIR}/git"
 SRCREV = "${AUTOREV}"

--- a/recipes-wam/wam/wam.bb
+++ b/recipes-wam/wam/wam.bb
@@ -12,7 +12,7 @@ PR="r0"
 PROVIDES += "virtual/webruntime"
 RPROVIDES_${PN} += "virtual/webruntime"
 
-SRC_URI = "git://github.com/webosose/${PN}.git;branch=@1.agl;protocol=https"
+SRC_URI = "git://github.com/Igalia/${PN}.git;branch=flounder;protocol=https"
 
 SRC_URI += "file://0001-Used-new-WindowManager-APIs.patch"
 

--- a/recipes-wam/wam/wam.bb
+++ b/recipes-wam/wam/wam.bb
@@ -17,6 +17,7 @@ SRC_URI = "git://github.com/Igalia/${PN}.git;branch=flounder;protocol=https"
 SRC_URI += "\
     file://0001-Used-new-WindowManager-APIs.patch \
     file://0001-Update-user-directory.patch \
+    file://0001-Remove-Restart-condition.patch \
 "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
These changes are required for running WAM on FF branch.

- Temporary repo change to igalia github for wam and chromium53.
- Updated user directory path for FF.
- Removed Restart to avoid continuous restarting loop. - It's also temporary.

TBR = @jdapena 