### PR TITLE
chromium53, wam: point back to webOS OSE repositories.

### DIFF
--- a/recipes-wam/chromium/chromium53.inc
+++ b/recipes-wam/chromium/chromium53.inc
@@ -7,7 +7,7 @@ DEPENDS_append = " af-main-native"
 # for bindings  af-binder is required.
 DEPENDS_append = " af-binder"
 
-SRC_URI = "git://github.com/Igalia/${PN}.git;branch=flounder;protocol=https"
+SRC_URI = "git://github.com/webosose/${PN}.git;branch=@1.agl.flounder;protocol=https"
 S = "${WORKDIR}/git"
 SRCREV = "${AUTOREV}"
 

--- a/recipes-wam/wam/wam.bb
+++ b/recipes-wam/wam/wam.bb
@@ -12,7 +12,7 @@ PR="r0"
 PROVIDES += "virtual/webruntime"
 RPROVIDES_${PN} += "virtual/webruntime"
 
-SRC_URI = "git://github.com/Igalia/${PN}.git;branch=flounder;protocol=https"
+SRC_URI = "git://github.com/webosose/${PN}.git;branch=@1.agl.flounder;protocol=https"
 S = "${WORKDIR}/git"
 SRCREV = "${AUTOREV}"
 


### PR DESCRIPTION
Move back to use https://github.com/webosose repositories
instead of Igalia github repositories.

[SPEC-1864] Merge WAM web runtime Igalia work from Igalia github in webOS OSE github
[SPEC-1866] Igalia meta-agl-lge should point to chromium53 and wam webosose repositories