### PR TITLE
Add chromium-browser-service

### DIFF
--- a/recipes-platform/packagegroups/packagegroup-agl-demo-platform-wam.bb
+++ b/recipes-platform/packagegroups/packagegroup-agl-demo-platform-wam.bb
@@ -24,6 +24,7 @@ RDEPENDS_${PN} += " \
 
 # add packages for OpenIVI-HTML5 demo
 RDEPENDS_${PN} += " \
+    chromium-browser-service \
     wam \
     wamdevmode \
     afm-widget-examples \

--- a/recipes-wam/chromium/chromium-browser-service.bb
+++ b/recipes-wam/chromium/chromium-browser-service.bb
@@ -1,0 +1,19 @@
+SUMMARY = "Chromium browser widget"
+DESCRIPTION = "Wgt packaging for running chromium installed browser"
+HOMEPAGE = "https://webosose.org"
+SECTION = "apps"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI = "gitsm://github.com/webosose/${PN}.git;branch=flounder;protocol=https"
+SRCREV = "${AUTOREV}"
+
+PV = "1.0+git${SRCPV}"
+S = "${WORKDIR}/git"
+
+#build-time dependencies
+DEPENDS += "af-binder af-main-native chromium68"
+
+inherit cmake aglwgt
+
+RDEPENDS_${PN} += "chromium68-browser runxdg"


### PR DESCRIPTION
It adds chromium-browser-service to support  the browser app.

[SPEC-1978] Adapt webOS OSE chromium68 and WAM to meta-agl-lge
https://jira.automotivelinux.org/browse/SPEC-1978